### PR TITLE
REFACTOR-#10: Update dependencies and enforce Modin

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modin_spreadsheet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An implementation for the Spreadsheet API of Modin",
   "author": "Modin Maintainers",
   "main": "src/index.js",

--- a/js/src/spreadsheet.widget.js
+++ b/js/src/spreadsheet.widget.js
@@ -36,8 +36,8 @@ class ModinSpreadsheetModel extends widgets.DOMWidgetModel {
       _view_name : 'ModinSpreadsheetView',
       _model_module : 'modin_spreadsheet',
       _view_module : 'modin_spreadsheet',
-      _model_module_version : '^0.1.0',
-      _view_module_version : '^0.1.0',
+      _model_module_version : '^0.1.1',
+      _view_module_version : '^0.1.1',
       _df_json: '',
       _columns: {}
     });

--- a/modin_spreadsheet/__init__.py
+++ b/modin_spreadsheet/__init__.py
@@ -35,8 +35,3 @@ __all__ = [
 
 __version__ = get_versions()["version"]
 del get_versions
-
-from ._version import get_versions
-
-__version__ = get_versions()["version"]
-del get_versions

--- a/modin_spreadsheet/__init__.py
+++ b/modin_spreadsheet/__init__.py
@@ -1,3 +1,8 @@
+try:
+    import modin.pandas as pd
+except ImportError:
+    raise ImportError("Please run `pip install modin`")
+
 from .grid import (
     enable,
     disable,

--- a/modin_spreadsheet/grid.py
+++ b/modin_spreadsheet/grid.py
@@ -575,8 +575,8 @@ class SpreadsheetWidget(widgets.DOMWidget):
     _model_name = Unicode("ModinSpreadsheetModel").tag(sync=True)
     _view_module = Unicode("modin_spreadsheet").tag(sync=True)
     _model_module = Unicode("modin_spreadsheet").tag(sync=True)
-    _view_module_version = Unicode("^0.1.0").tag(sync=True)
-    _model_module_version = Unicode("^0.1.0").tag(sync=True)
+    _view_module_version = Unicode("^0.1.1").tag(sync=True)
+    _model_module_version = Unicode("^0.1.1").tag(sync=True)
 
     _df = Union([Instance(pd.DataFrame), Instance(pandas.DataFrame)])
     _df_json = Unicode("", sync=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-notebook>=4.0.0
-pandas>=0.18.0
+jupyter>=1.0.0
+notebook>=6.0.3
 ipywidgets>=7.0.0

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ setup_args = {
     ],
     "install_requires": reqs,
     "extras_require": extras_require(),
+    "python-requires": ">=3.6.1",
     "packages": find_packages(),
     "zip_safe": False,
     "author": "Modin Maintainers",


### PR DESCRIPTION
Changes summarized below. Will update to v0.1.1 once approved

Dependencies:
- Remove dependency on Pandas
- Update Jupyter requirements
- Require Python>=3.6.1

Other:
- Remove redundant versioneer code
- Enforce `Modin` package installation
- Update package version in the widget