### PR TITLE
FEAT-#23: Add filter relevant history functionality

### DIFF
--- a/js/src/spreadsheet.widget.js
+++ b/js/src/spreadsheet.widget.js
@@ -118,6 +118,12 @@ class ModinSpreadsheetView extends widgets.DOMWidgetView {
     });
 
     append_btn({
+      loading_text: 'Filtering...',
+      event_type: 'filter_history',
+      text: 'Filter History'
+    });
+
+    append_btn({
       loading_text: 'Resetting...',
       text: 'Reset Filters',
       handler_function: 'reset_all_filters'

--- a/modin_spreadsheet/constants.py
+++ b/modin_spreadsheet/constants.py
@@ -1,0 +1,20 @@
+HISTORY_PREFIX = "# ---- spreadsheet transformation history ----\n"
+
+# Transformation History Prefixes
+# Row
+ADD_ROW = "# Add row"
+REMOVE_ROWS = "# Remove rows"
+
+# Edit
+EDIT_CELL = "# Edit cell"
+
+# Filter
+FILTER_COLUMNS = "# Filter columns"
+RESET_FILTER = "# Reset filter"
+RESET_ALL_FILTERS = "# Reset all filters"
+
+# Sort
+SORT_COLUMN = "# Sort column"
+SORT_MIXED_TYPE_COLUMN = "# Sort mixed type column"
+SORT_INDEX = "# Sort index"
+RESET_SORT = "# Reset sort"

--- a/modin_spreadsheet/grid.py
+++ b/modin_spreadsheet/grid.py
@@ -1672,6 +1672,9 @@ class SpreadsheetWidget(widgets.DOMWidget):
             self._update_history_cell()
         elif content["type"] == "clear_history":
             self.clear_history(from_api=False)
+        elif content["type"] == "filter_history":
+            self._filter_relevant_history(persist=True)
+            self._notify_listeners({"name": "history_filtered", "source": "gui"})
 
     def _notify_listeners(self, event):
         # notify listeners at the module level
@@ -2034,6 +2037,11 @@ class SpreadsheetWidget(widgets.DOMWidget):
         self.send({"type": "reset_filters"})
 
     def filter_relevant_history(self, persist=True):
+        relevant_history = self._filter_relevant_history(persist)
+        self._notify_listeners({"name": "history_filtered", "source": "api"})
+        return relevant_history
+
+    def _filter_relevant_history(self, persist):
         history = self.get_history()
         relevant_history = []
         # Whether a filter or sort can still be added
@@ -2071,4 +2079,5 @@ class SpreadsheetWidget(widgets.DOMWidget):
         # Change internal state if persisting
         if persist:
             self._history = relevant_history
+            self._update_history_cell()
         return relevant_history

--- a/modin_spreadsheet/grid.py
+++ b/modin_spreadsheet/grid.py
@@ -24,6 +24,7 @@ from traitlets import (
 from itertools import chain
 from uuid import uuid4
 from six import string_types
+from . import constants
 
 # versions of pandas prior to version 0.20.0 don't support the orient='table'
 # when calling the 'to_json' function on DataFrames.  to get around this we
@@ -133,7 +134,6 @@ class _EventHandlers(object):
 
 defaults = _DefaultSettings()
 handlers = _EventHandlers()
-HISTORY_PREFIX = "# ---- spreadsheet transformation history ----\n"
 
 
 def set_defaults(
@@ -1095,7 +1095,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
                     self._df.sort_index(ascending=self._sort_ascending, inplace=True)
                     # Record sort index
                     self._record_transformation(
-                        f"# Sort index\n"
+                        f"{constants.SORT_INDEX}\n"
                         f"df.sort_index(ascending={self._sort_ascending}, inplace=True)"
                     )
                 else:
@@ -1106,7 +1106,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
                     # Record sort index
                     # TODO: Fix level=level_index
                     self._record_transformation(
-                        f"# Sort index\n"
+                        f"{constants.SORT_INDEX}\n"
                         f"df.sort_index(level=level_index, ascending={self._sort_ascending}, "
                         f"inplace=True)"
                     )
@@ -1118,7 +1118,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
                 )
                 # Record sort column
                 self._record_transformation(
-                    f"# Sort column\n"
+                    f"{constants.SORT_COLUMN}\n"
                     f"df.sort_values('{self._sort_field}', ascending={self._sort_ascending}, "
                     f"inplace=True)"
                 )
@@ -1138,7 +1138,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
             helper_col = self._sort_field + self._sort_col_suffix
             self._record_transformation(
                 (
-                    f"#Sort mixed type column\n"
+                    f"{constants.SORT_MIXED_TYPE_COLUMN}\n"
                     f"df['{helper_col}'] = df['{self._sort_field}'].map(str)\n"
                     f"df.sort_values('{helper_col}', ascending={self._sort_ascending}, inplace=True)\n"
                     f"df.drop(columns='{helper_col}', inplace=True)"
@@ -1466,7 +1466,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
             # Record reset filter
             # Other filters and sorts are reapplied after
             self._record_transformation(
-                f"# Reset filter\n" f"df = unfiltered_df.copy()"
+                f"{constants.RESET_FILTER}\n" f"df = unfiltered_df.copy()"
             )
         else:
             combined_condition = conditions[0]
@@ -1479,7 +1479,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
                 ["(" + c + ")" for c in self._filter_conditions]
             )
             self._record_transformation(
-                f"# Filter columns\n"
+                f"{constants.FILTER_COLUMNS}\n"
                 f"df = unfiltered_df[{record_combined_condition}].copy()"
             )
             # Reset filter conditions
@@ -1527,7 +1527,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
                 self._df.loc[location] = val_to_set
                 # Record cell edit
                 self._record_transformation(
-                    f"# Edit cell\n"
+                    f"{constants.EDIT_CELL}\n"
                     f"df.loc[{location}]={repr(val_to_set)}\n"
                     f"unfiltered_df.loc[{location}]={repr(val_to_set)}"
                 )
@@ -1656,7 +1656,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
             self._resetting_filters = False
             # Record reset filters before updating sort
             self._record_transformation(
-                ("# Reset all filters\n" "df = unfiltered_df.copy()")
+                (f"{constants.RESET_ALL_FILTERS}\n" "df = unfiltered_df.copy()")
             )
             self._update_sort()
             self._update_table(triggered_by="reset_filters")
@@ -1769,7 +1769,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
         )
         # Record row add
         self._record_transformation(
-            f"# Add row\n"
+            f"{constants.ADD_ROW}\n"
             f"last = df.loc[max(df.index)].copy()\n"
             f"df.loc[last.name+1] = last.values\n"
             f"unfiltered_df.loc[last.name+1] = last.values"
@@ -1899,7 +1899,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
         self._update_table(triggered_by="remove_row")
         # Record remove rows
         self._record_transformation(
-            f"# Remove rows\n"
+            f"{constants.REMOVE_ROWS}\n"
             f"df.drop({selected_names}, inplace=True)\n"
             f"unfiltered_df.drop({selected_names}, inplace=True)"
         )
@@ -1982,7 +1982,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
 
     def _update_history_cell(self):
         cleaned_history = "\n".join(self._history)
-        cell_text = HISTORY_PREFIX + cleaned_history
+        cell_text = constants.HISTORY_PREFIX + cleaned_history
         self.send(
             {
                 "type": "update_history",
@@ -2025,7 +2025,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
         # Record sort index
         # After update_table to prevent resetting in progress button prematurely
         self._record_transformation(
-            f"# Reset sort\n" f"df.sort_index(ascending=True, inplace=True)"
+            f"{constants.RESET_SORT}\n" f"df.sort_index(ascending=True, inplace=True)"
         )
         source = "api" if from_api else "gui"
         self._notify_listeners({"name": "sort_reset", "source": source})

--- a/modin_spreadsheet/tests/test_grid.py
+++ b/modin_spreadsheet/tests/test_grid.py
@@ -850,13 +850,13 @@ def test_get_history():
         {"type": "change_sort", "sort_field": "A", "sort_ascending": True}
     )
     last_history = spreadsheet.get_history()[-1]
-    expected_history = "#Sort mixed type column\ndf['A_modin_spreadsheet_sort_column'] = df['A'].map(str)\ndf.sort_values('A_modin_spreadsheet_sort_column', ascending=True, inplace=True)\ndf.drop(columns='A_modin_spreadsheet_sort_column', inplace=True)"
+    expected_history = "# Sort mixed type column\ndf['A_modin_spreadsheet_sort_column'] = df['A'].map(str)\ndf.sort_values('A_modin_spreadsheet_sort_column', ascending=True, inplace=True)\ndf.drop(columns='A_modin_spreadsheet_sort_column', inplace=True)"
     assert last_history == expected_history
 
     # Reset filters
     spreadsheet._handle_view_msg_helper({"type": "reset_filters_end"})
     last_history = spreadsheet.get_history()[-1]
-    expected_history = "#Sort mixed type column\ndf['A_modin_spreadsheet_sort_column'] = df['A'].map(str)\ndf.sort_values('A_modin_spreadsheet_sort_column', ascending=True, inplace=True)\ndf.drop(columns='A_modin_spreadsheet_sort_column', inplace=True)"
+    expected_history = "# Sort mixed type column\ndf['A_modin_spreadsheet_sort_column'] = df['A'].map(str)\ndf.sort_values('A_modin_spreadsheet_sort_column', ascending=True, inplace=True)\ndf.drop(columns='A_modin_spreadsheet_sort_column', inplace=True)"
     assert last_history == expected_history
 
     # Reset sort


### PR DESCRIPTION
Resolves #23. This PR adds the functionality to filter the transformation history so that only the commands that contribute to the final state of the spreadsheet remain. The functionality can be invoked through API as `spreadsheet.filter_relevant_history()` and through the GUI as a button. By default, the function changes the internal history state, but this can be avoided with `spreadsheet.filter_relevant_history(persist=False)`.

Testing:
- Added test for filter_relevant_history testing, should cover most common use cases

This PR also refactors string values into a new file `constants.py` so that they can be accessed using variables (reduce errors, easier to test, increase readability).

**Thoughts on API name and parameter?** 